### PR TITLE
Only use Google Analytics in production

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -17,7 +17,9 @@
     <link href="{{ .RSSLink }}" rel="alternate" type="application/rss+xml" title="{{ .Site.Title }}" />
     {{- end -}}
 
+    {{ if eq .Site.IsServer false }}
     {{ template "_internal/google_analytics_async.html" . }}
+    {{ end }}
 
     {{ partial "head_custom" . }}
 </head>


### PR DESCRIPTION
The dev environment pollutes Google Analytics stats as a result of constant reloading of pages when changes are made. This PR ensures the analytics snippet is not loaded when the Hugo dev server is running.