### PR TITLE
Replace the deprecated RSSLink with the recommended workaround

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -13,8 +13,8 @@
         {{- $styles.Content | safeCSS -}}
     </style>
 
-    {{- if .RSSLink }}
-    <link href="{{ .RSSLink }}" rel="alternate" type="application/rss+xml" title="{{ .Site.Title }}" />
+    {{- if .OutputFormats.Get "RSS" }}
+    <link href="{{ with .OutputFormats.Get "RSS" }}{{ .RelPermalink }}{{ end }}" rel="alternate" type="application/rss+xml" title="{{ .Site.Title }}" />
     {{- end -}}
 
     {{ template "_internal/google_analytics_async.html" . }}


### PR DESCRIPTION
I just upgraded to Hugo 0.58.3, and looks like `.RSSLink` is now deprecated:

https://gohugo.io/variables/page/#page-variables

Replacing with the recommended solution here to remove the warning.