### PR TITLE
A11y, I18n: add missing "lang" attr

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="{{- default "" .Site.LanguageCode" -}}">
 {{ partial "head.html" . }}
 
 <body>


### PR DESCRIPTION
Adding a language code is necessary for machine translation, screen readers, and other technologies to work correctly.